### PR TITLE
Check if cordova is installed before exec

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const hasbin = require('hasbin')
 const defaults = require('./defaults')
 const { spawnSync } = require('child_process')
 const { info } = require('@vue/cli-shared-utils')
@@ -61,6 +62,12 @@ module.exports = (api, options) => {
   })
 
   api.onCreateComplete(() => {
+    // early return if cordova binary is not found
+    const hasCordova = hasbin.sync('cordova');
+    if (!hasCordova) {
+      api.exitLog(`Unable to find cordova binary, make sure it's installed.`, 'error')
+      return
+    }
     // .gitignore - not included in files on postProcessFiles
     const ignorePath = '.gitignore'
     const ignoreCompletePath = api.resolve(ignorePath)

--- a/generator.js
+++ b/generator.js
@@ -5,6 +5,12 @@ const { spawnSync } = require('child_process')
 const { info } = require('@vue/cli-shared-utils')
 
 module.exports = (api, options) => {
+  // early return if cordova binary is not found
+  const hasCordova = hasbin.sync('cordova')
+  if (!hasCordova) {
+    api.exitLog(`Unable to find cordova binary, make sure it's installed.`, 'error')
+    return
+  }
   // cordova options
   const cordovaPath = options.cordovaPath || defaults.cordovaPath
   const id = options.id || defaults.id
@@ -62,12 +68,6 @@ module.exports = (api, options) => {
   })
 
   api.onCreateComplete(() => {
-    // early return if cordova binary is not found
-    const hasCordova = hasbin.sync('cordova');
-    if (!hasCordova) {
-      api.exitLog(`Unable to find cordova binary, make sure it's installed.`, 'error')
-      return
-    }
     // .gitignore - not included in files on postProcessFiles
     const ignorePath = '.gitignore'
     const ignoreCompletePath = api.resolve(ignorePath)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "vue-cli-plugin-cordova",
-  "version": "2.0.2",
+  "name": "@m0dch3n/vue-cli-plugin-cordova",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@m0dch3n/vue-cli-plugin-cordova",
-  "version": "0.0.1",
+  "name": "vue-cli-plugin-cordova",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1554,6 +1554,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "hasbin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/hasbin/-/hasbin-1.2.3.tgz",
+      "integrity": "sha1-eMWSaJPIAhXCtWiuH9P8q3omlrA=",
+      "requires": {
+        "async": "~1.5"
+      }
     },
     "hoek": {
       "version": "5.0.4",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@vue/cli-shared-utils": "^3.0.2",
     "address": "^1.0.3",
     "cordova-plugin-device": "^2.0.1",
+    "hasbin": "^1.2.3",
     "html-webpack-include-assets-plugin": "^1.0.4",
     "portfinder": "^1.0.13"
   },

--- a/prompts.js
+++ b/prompts.js
@@ -1,6 +1,15 @@
+const hasbin = require('hasbin')
 const defaults = require('./defaults')
+const hasCordova = hasbin.sync('cordova')
 
-module.exports = [
+const cordovaBinaryMissing = {
+  name: 'cordovaDeppendency',
+  type: 'string',
+  message: 'Unable to find cordova binary, make sure it\'s installed.',
+  default: 'Quit'
+}
+
+const prompts = [
   {
     name: 'cordovaPath',
     type: 'string',
@@ -45,3 +54,5 @@ module.exports = [
     ]
   }
 ]
+
+module.exports = !hasCordova ? cordovaBinaryMissing : prompts


### PR DESCRIPTION
Prevents the cordova commands to fail silently when the cordova binary is not present.