### PR TITLE
Fix package-lock name and version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@m0dch3n/vue-cli-plugin-cordova",
-  "version": "0.0.1",
+  "name": "vue-cli-plugin-cordova",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Not sure if this could be automated, but it's a matter of keep the package-lock in sync when doing a release. I saw the project uses `standard-version` for releases, and I've no experience with this package. 

I'll take a look to see if this can be part of the release process, either way this fixes the name and version for now.