### PR TITLE
replace baseUrl with publicPath

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -26,9 +26,10 @@ module.exports = (api, options) => {
       'cordova-build-ios': 'vue-cli-service cordova-build-ios',
       'cordova-serve-browser': 'vue-cli-service cordova-serve-browser',
       'cordova-build-browser': 'vue-cli-service cordova-build-browser'
+      'cordova-prepare': 'vue-cli-service cordova-prepare'
     },
     vue: {
-      baseUrl: '',
+      publicPath: '',
       pluginOptions: {
         cordovaPath
       }
@@ -116,4 +117,3 @@ module.exports = (api, options) => {
     })
   })
 }
-


### PR DESCRIPTION
[3.3.0](https://github.com/vuejs/vue-cli/blob/dev/CHANGELOG.md)
deprecate confusing baseUrl option, use publicPath instead. 