### PR TITLE
Check what devServer settings a user has applied instead of hardcoding 

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ module.exports = (api, options) => {
       const projectDevServerOptions = options.devServer || {}
       // resolve server options
       const open = false // browser does not need to be opened
-      const https = options.devServer.https // check devServer.options for user defined https setting
+      const https = options.devServer.https || false // check devServer.options for user defined https setting
       const protocol = https ? 'https' : 'http'
       const host = args.host || process.env.HOST || projectDevServerOptions.host || defaultServe.host
       let port = args.port || process.env.PORT || projectDevServerOptions.port || defaultServe.port

--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ module.exports = (api, options) => {
       const projectDevServerOptions = options.devServer || {}
       // resolve server options
       const open = false // browser does not need to be opened
-      const https = false // cordova webpage must be served via http
+      const https = options.devServer.https // check devServer.options for user defined https setting
       const protocol = https ? 'https' : 'http'
       const host = args.host || process.env.HOST || projectDevServerOptions.host || defaultServe.host
       let port = args.port || process.env.PORT || projectDevServerOptions.port || defaultServe.port


### PR DESCRIPTION
With the release of Cordova Android 8.0.0, the app needs to be served over https. Currently the plugin has hardcoded https to false. The app should check if the user has set devServer.https to true in the vue.config.js and use this setting instead. This option defaults to false, so should not break older apps using the plugin.