### PR TITLE
Config template

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ During installation, the plugin is setting some important variables, modifying t
 * Setting cordovaPath in **vue.config.js**
 * Checking if **router** is available and modify router mode to **'hash'** if process.env.CORDOVA_PLATFORM is set
 * Adding ignore paths for cordova in **.gitignore**
+* Adding cordova before_prepare hook in  **config.xml**
 * Executing '**cordova create cordovaPath id appName**' (cordovaPath, id and appName will be **prompted**)
 * Executing '**cordova platform add platform**' (platform will be prompted)
 
@@ -44,9 +45,9 @@ It is doing this by:
 * Adding **cordova.js** to your **index.html**
 * Defining **process.env.CORDOVA_PLATFORM** to **android**, **ios** or **browser**
 * Starting the Dev Server
-* Pointing the cordova **config.xml** to Dev Server
 * Executing '**cordova clean**'
 * Executing '**cordova run platform**'
+* Pointing the cordova **config.xml** to Dev Server in hook
 
 ### In Production mode
 
@@ -56,7 +57,6 @@ It is doing this by:
 
 * Adding **cordova.js** to your **index.html**
 * Defining **process.env.CORDOVA_PLATFORM** to **android**, **ios** or **browser***
-* Pointing the cordova **config.xml** to **index.html**
 * Building the app, output to **/src-cordova/www**
 * Executing '**cordova clean**'
 * Executing '**cordova build platform  --release**'

--- a/defaults.js
+++ b/defaults.js
@@ -1,5 +1,10 @@
 module.exports = {
   cordovaPath: 'src-cordova',
+  cordovaConfigPaths: {
+    android: 'app/src/main/res/xml/config.xml',
+    ios: 'VueExampleAppName/config.xml',
+    osx: 'config.xml',
+  },
   id: 'com.vue.example.app',
   appName: 'VueExampleAppName',
   platforms: ['android', 'ios', 'browser', 'osx'],

--- a/serve-config-hook.js
+++ b/serve-config-hook.js
@@ -1,0 +1,23 @@
+const fs = require('fs')
+const { info } = require('@vue/cli-shared-utils')
+
+const url = process.env.CORDOVA_WEBVIEW_SRC
+const cordovaConfigPath = process.env.CORDOVA_PREPARE_CONFIG
+if (!url || !cordovaConfigPath) {
+  return
+}
+info(`updating cordova config.xml content to ${url}`)
+
+let cordovaConfig = fs.readFileSync(cordovaConfigPath, 'utf-8')
+let lines = cordovaConfig.split(/\r?\n/g).reverse()
+const regexContent = /\s+<content/
+const contentIndex = lines.findIndex(line => line.match(regexContent))
+const allowNavigation = `    <allow-navigation href="${url}" />`
+if (contentIndex >= 0) {
+  lines[contentIndex] = `    <content src="${url}" />`
+  if (url) {
+    lines.splice(contentIndex, 0, allowNavigation)
+  }
+  cordovaConfig = lines.reverse().join('\n')
+  fs.writeFileSync(cordovaConfigPath, cordovaConfig)
+}


### PR DESCRIPTION
This tries to solve #63 although with a somewhat less elegant approach.

`cordova.xml` is copied to `cordova.template.xml` during generation and `cordova.xml` is put into `.gitignore` this allows to have it in version control and not be annoyed by the changes for the Dev Server.

Unfortunately there is a problem which is changes can come in either from `cordova.template.xml` via version control or during a plugin installation to `cordova.xml` which means there is no source of truth and the complexity has to be handled by the developers.