### PR TITLE
Custom path for cordova.js by vue.config.js publicPath

### DIFF
--- a/index.js
+++ b/index.js
@@ -260,7 +260,7 @@ module.exports = (api, options) => {
         .use(require('html-webpack-include-assets-plugin'), [{
           assets: 'cordova.js',
           append: false,
-          publicPath: false
+          publicPath: options.publicPath !== undefined ? options.publicPath : false
         }])
 
       // process.env.CORDOVA_PLATFORM = platform


### PR DESCRIPTION
Use the publicPath defined in vue.config.js in html-webpack-include-assets-plugin options to attach cordova.js into the index.html with a custom path. Fix the issue #115